### PR TITLE
lnlambda: prepare release

### DIFF
--- a/packages/lnlambda/CHANGELOG.md
+++ b/packages/lnlambda/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.0.1-beta.5
+
+## Fixes
+- fix header ([commit](https://github.com/dart-lightning/lndart.cln/commit/645ff26cb5db723abb882936e4a02e0bbdf172d9)). @vincenzopalazzo 13-08-2022
+
+
 # v0.0.1-beta.4
 
 ## Fixes

--- a/packages/lnlambda/changelog.json
+++ b/packages/lnlambda/changelog.json
@@ -1,6 +1,6 @@
 {
   "package_name": "lnlambda",
-  "version": "v0.0.1-beta.4",
+  "version": "v0.0.1-beta.5",
   "api": {
     "name": "github",
     "repository": "dart-lightning/lndart.cln",

--- a/packages/lnlambda/pubspec.yaml
+++ b/packages/lnlambda/pubspec.yaml
@@ -1,6 +1,6 @@
 name: lnlambda
 description: Minimal interface to run lnlambda function with dart.
-version: 0.0.1-beta.4
+version: 0.0.1-beta.5
 homepage: https://github.com/dart-lightning/lndart.clightning
 
 environment:


### PR DESCRIPTION
## Fixes
- fix header ([commit](https://github.com/dart-lightning/lndart.cln/commit/645ff26cb5db723abb882936e4a02e0bbdf172d9)). @vincenzopalazzo 13-08-2022


Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>