### PR TITLE
fix-build: temporary fix for  lndart.cln packages check fail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ default: analyze
 
 dep:
 	dart pub global activate melos;
-	dart pub global activate spec_cli;
+#	dart pub global activate spec_cli;
 	dart pub global activate changelog_cmd;
 	$(CC) bootstrap
 


### PR DESCRIPTION
There were recent breaking changes in riverpod which were pulled by `spec_cli` as mentioned here:
https://github.com/invertase/spec/issues/28
There is a temporary PR for the fix:
https://github.com/invertase/spec/pull/30
This PR is only to provide a temporary fix, and is only here to address the issue, but is in no way a solution.