### PR TITLE
fix : fixes the parsing of json to throw exception.

### DIFF
--- a/packages/lnlambda/lib/src/lnlambda_base.dart
+++ b/packages/lnlambda/lib/src/lnlambda_base.dart
@@ -58,7 +58,7 @@ class LNLambdaClient implements LightningClient {
         },
         body: json.encode(request.toJSON()));
     Map<String, dynamic> result = json.decode(response.body);
-    if (result.containsKey("errors")) {
+    if (result.containsKey("error")) {
       throw Exception(response.body);
     }
     return result["result"];


### PR DESCRIPTION
The json received in case of any error is of the type `{error: {code: -32602, message: This payment is destined for ourselves. Self-payments are not supported}, id: (null)commando:pay#106, jsonrpc: 2.0}`. For now the exceptions are thrown by checking if it contains the `errors` key. But it should be `error` as mentioned in the above response.